### PR TITLE
Support gauge and counter metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Integrate sparkMeasure for Enhanced Performance Monitoring
 
+This demo exposes metrics through JMX using both **gauges** and **counters**.
+Metrics can be scraped by Prometheus thanks to the provided JMX exporter
+configuration.
+
 # How to run the demo
 
 ## Pre-requisites
@@ -29,6 +33,10 @@ kubectl get pods -n spark-demo
 # Dump the metrics from the prometheus exporter of the spark job
 # spark-measure metrics appears ~10 seconds after job startup
 ./check-metrics.sh | grep measure
+
+The `spark-sql.py` example publishes sparkMeasure metrics as gauges and also
+updates a counter named `metrics_published_total` using `setCounter` each time
+metrics are sent via JMX.
 ```
 
 > ⚠️ **Warning**

--- a/TODO.org
+++ b/TODO.org
@@ -1,4 +1,4 @@
-* TODO difference between gauge and counter?? + package
+* DONE difference between gauge and counter?? + package
 * TODO répondre à Luca https://github.com/LucaCanali/sparkMeasure/issues/67
 * DONE read MBean doc: https://www.jmdoudoux.fr/java/dej/chap-jmx.htm#jmx-4
 * DONE monitor issue about stagemetrics.print_memory_report()  https://github.com/LucaCanali/sparkMeasure/issues/65

--- a/charts/spark-demo/templates/jmx-configmap.yaml
+++ b/charts/spark-demo/templates/jmx-configmap.yaml
@@ -16,6 +16,12 @@ data:
         labels:
           app_namespace: "$1"
           app_id: "$2"
+      - pattern: sparkmeasure\.metrics<name=(\S+)\.(\S+)\.(\S+),\s*type=counters><>Count
+        name: sparkmeasure_$3_total
+        type: COUNTER
+        labels:
+          app_namespace: "$1"
+          app_id: "$2"
       # Rules from https://github.com/prometheus/jmx_exporter/blob/main/examples/spark.yml
       - pattern: metrics<name=(\S+)\.(\S+)\.driver\.(BlockManager|DAGScheduler|jvm)\.(\S+)><>Value
         name: spark_driver_$3_$4

--- a/rootfs/opt/spark/examples/src/main/python/spark-sql.py
+++ b/rootfs/opt/spark/examples/src/main/python/spark-sql.py
@@ -17,10 +17,15 @@ def publish_metrics(spark_session, metrics: Dict[str, Union[float, int]]):
         dropwizard = spark_session._jvm.ch.cern.metrics.DropwizardMetrics
         for key, value in metrics.items():
             dropwizard.setGauge(key, float(value))
+        # Example counter to track the number of times metrics have been published
+        publish_metrics.publish_count += 1
+        dropwizard.setCounter("metrics_published_total", publish_metrics.publish_count)
 
         print(f"[INFO] {len(metrics)} Dropwizard metrics published via JMX")
     except Exception as e:
         print(f"[ERROR] Failed to publish Dropwizard metrics: {e}")
+
+publish_metrics.publish_count = 0
 
 def run_my_workload(spark):
 


### PR DESCRIPTION
## Summary
- expose metrics as gauges and counters in README
- add counter example in `spark-sql.py`
- support counters in DropwizardMetrics Scala helper
- scrape counters via JMX exporter config
- mark TODO about gauge vs counter done
- implement `setCounter` helper

## Testing
- `bash build.sh -h`
- `sbt package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ad2d165688325b73cc60ba68676ab