### PR TITLE
Fix StageMetrics to use passed Spark session

### DIFF
--- a/rootfs/opt/spark/examples/src/main/python/spark-wordcount.py
+++ b/rootfs/opt/spark/examples/src/main/python/spark-wordcount.py
@@ -31,7 +31,7 @@ def main():
     # Définir le pipeline avec foreachBatch
     query = word_counts.writeStream \
         .outputMode("complete") \
-        .foreachBatch(metrics.process_batch) \
+        .foreachBatch(lambda df, batch_id: metrics.process_batch(df, batch_id, spark)) \
         .option("checkpointLocation", "/tmp/spark-checkpoint/wordcount") \
         .start()
 

--- a/rootfs/opt/spark/python/metrics.py
+++ b/rootfs/opt/spark/python/metrics.py
@@ -1,10 +1,11 @@
 from typing import Union, Dict
 
 from sparkmeasure import StageMetrics
+import datetime
 
 # Callback foreachBatch avec StageMetrics
-def process_batch(df, batch_id):
-    stagemetrics = StageMetrics(spark)
+def process_batch(df, batch_id, spark_session):
+    stagemetrics = StageMetrics(spark_session)
     stagemetrics.begin()
 
     df.cache().count()  # force plan exécution


### PR DESCRIPTION
## Summary
- import `datetime` for metric timestamping
- pass Spark session into `process_batch`
- update wordcount example to provide the session

## Testing
- `python3 -m py_compile rootfs/opt/spark/python/metrics.py`
- `python3 -m py_compile rootfs/opt/spark/examples/src/main/python/spark-wordcount.py`


------
https://chatgpt.com/codex/tasks/task_e_6852b41716008325b3f83e4ba3c72ee9